### PR TITLE
Fix WaitablePQueue remove and timeout behaviour

### DIFF
--- a/src/WaitablePQueue/WaitablePQueue.java
+++ b/src/WaitablePQueue/WaitablePQueue.java
@@ -40,17 +40,46 @@ public class WaitablePQueue<E> {
     }
 
     public E dequeue(long timeout, TimeUnit unit) {
-        return dequeue();
-    }
-
-    public boolean remove(E element) {
-
-        synchronized (priorityQueue) {
-            return priorityQueue.remove(element);
+        try {
+            if(!emptySem.tryAcquire(timeout, unit)){
+                return null;
+            }
+            synchronized (priorityQueue){
+                return priorityQueue.poll();
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Sem", e);
         }
     }
 
+    public boolean remove(E element) {
+        boolean removed;
+        synchronized (priorityQueue) {
+            removed = priorityQueue.remove(element);
+        }
+        if(removed){
+            emptySem.tryAcquire();
+        }
+        return removed;
+    }
+
     public boolean remove(E element, long timeout, TimeUnit unit) {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        while(System.nanoTime() < deadline){
+            if(remove(element)){
+                return true;
+            }
+            try {
+                long remaining = deadline - System.nanoTime();
+                if(remaining > 0){
+                    if(emptySem.tryAcquire(remaining, TimeUnit.NANOSECONDS)){
+                        emptySem.release();
+                    }
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Sem", e);
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
## Summary
- implement timeout logic in `dequeue(long, TimeUnit)`
- fix `remove` to keep semaphore count consistent
- implement timed version of `remove`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68415487317c832c9fab669e2eed5316